### PR TITLE
Ignore DateTimeToDateTimeInterfaceRector as treating mutable vs immutable in same fashion is dangerous

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Rector\CodeQuality\Rector\ClassMethod\DateTimeToDateTimeInterfaceRector;
 use Rector\Core\Configuration\Option;
 use Rector\Core\ValueObject\PhpVersion;
 use Rector\Set\ValueObject\SetList;
@@ -13,6 +14,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_74);
     $parameters->set(Option::ENABLE_CACHE, true);
     $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, __DIR__.'/phpstan.neon');
+    $parameters->set(Option::SKIP, [
+        DateTimeToDateTimeInterfaceRector::class,
+    ]);
 
     $containerConfigurator->import(SetList::CODE_QUALITY);
     $containerConfigurator->import(SetList::CODE_QUALITY_STRICT);


### PR DESCRIPTION
You cannot reason about the functionality of `\DateTimeInterface` as a return value as it may or may not have side-effect free methods. It's (I believe) only valuable as a parameter type so your code can (safely) consume either types (likely requiring a clone / conversion internally).

See failing CI where return types are being changed in an unwanted manner https://github.com/Lendable/clock/pull/63/checks?check_run_id=3445932232