### PR TITLE
Improve validation of persisted data, comply with PHPStan checkExplicitMixed

### DIFF
--- a/lib/PersistedFixedClock.php
+++ b/lib/PersistedFixedClock.php
@@ -77,6 +77,25 @@ final class PersistedFixedClock implements MutableClock
         $contents = \file_get_contents($path);
         \assert(\is_string($contents));
         $data = \json_decode($contents, true, 512, \JSON_THROW_ON_ERROR);
+
+        if (!is_array($data)) {
+            throw new \RuntimeException(
+                \sprintf(
+                    'Expected data to decode to an array, but got %s.',
+                    get_debug_type($data)
+                )
+            );
+        }
+
+        if (!isset($data['timestamp'], $data['timezone'])) {
+            throw new \RuntimeException(
+                \sprintf(
+                    'Expected to decode to an associative array containing keys timestamp and timezone. Got keys [%s].',
+                    implode(', ', \array_map(static fn ($k): string => '"'.$k.'"', \array_keys($data)))
+                )
+            );
+        }
+
         $now = \DateTimeImmutable::createFromFormat(
             self::SERIALIZATION_FORMAT,
             $data['timestamp'],

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,8 @@ includes:
 parameters:
     level: max
     reportUnmatchedIgnoredErrors: false
-    
+    checkExplicitMixed: true
+ 
     ignoreErrors:
         - '#Dynamic call to static method PHPUnit\\Framework\\.*#'
         - '#^Call to an undefined static method DateTime(?:Immutable)?::createFromInterface\(\)\.$#'

--- a/tests/unit/DateTest.php
+++ b/tests/unit/DateTest.php
@@ -194,7 +194,7 @@ final class DateTest extends TestCase
     }
 
     /**
-     * @return iterable<mixed>
+     * @return iterable<array{0: string, 1: string}>
      */
     public function provideDatesForDayAfterIncrementData(): iterable
     {
@@ -217,7 +217,7 @@ final class DateTest extends TestCase
     }
 
     /**
-     * @return iterable<mixed>
+     * @return iterable<array{string, string}>
      */
     public function provideDatesForDayBeforeIncrementData(): iterable
     {
@@ -241,7 +241,7 @@ final class DateTest extends TestCase
     }
 
     /**
-     * @return iterable<mixed>
+     * @return iterable<array{0: string, 1: string, 2: bool}>
      */
     public function provideValuesForBeforeComparisonData(): iterable
     {
@@ -269,7 +269,7 @@ final class DateTest extends TestCase
     }
 
     /**
-     * @return iterable<mixed>
+     * @return iterable<array{0: string, 1: string, 2: bool}>
      */
     public function provideValuesForBeforeOrEqualToComparisonData(): iterable
     {


### PR DESCRIPTION
https://twitter.com/OndrejMirtes/status/1437289210524938243

This changeset fixes the below errors reported with `checkExplicitMixed` enabled. 

```
❯ composer static
./composer.json is valid
> parallel-lint lib
PHP 7.4.21 | 10 parallel jobs
...........                                                  11/11 (100 %)


Checked 11 files in 0 seconds
No syntax error found
> parallel-lint tests
PHP 7.4.21 | 10 parallel jobs
.......                                                      7/7 (100 %)


Checked 7 files in 0 seconds
No syntax error found
> phpstan analyse -l 7 lib/ tests/ --ansi --no-progress
Note: Using configuration file /home/ben/Documents/code/lendable/libraries/clock/phpstan.neon.
 ------ -------------------------------------------- 
  Line   lib/PersistedFixedClock.php                 
 ------ -------------------------------------------- 
  82     Cannot access offset 'timestamp' on mixed.  
  83     Cannot access offset 'timezone' on mixed.   
 ------ -------------------------------------------- 

 ------ --------------------------------------------------------------------------- 
  Line   tests/unit/DateTest.php                                                    
 ------ --------------------------------------------------------------------------- 
  225    Parameter #1 $input of function array_reverse expects array, mixed given.  
 ------ --------------------------------------------------------------------------- 

                                                                                                                        
 [ERROR] Found 3 errors                                                                                                 
                                                                                                                        

Script phpstan analyse -l 7 lib/ tests/ --ansi --no-progress handling the phpstan event returned with error code 1
Script @phpstan was called via static-analysis
```