### PR TITLE
Require minimum of 1.6.10 for mikey179/vfsStream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "ext-json": "*",
     "friendsofphp/php-cs-fixer": "^3.0",
     "liuggio/fastest": "^1.8",
-    "mikey179/vfsstream": "^1.6.8",
+    "mikey179/vfsstream": "^1.6.10",
     "php-parallel-lint/php-parallel-lint": "^1.3",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-deprecation-rules": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d971599a9fa712a58b33675e6f84f84f",
+    "content-hash": "f030fe6f971f5288104c3abd243c5927",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
Running the test suite against PHP 8.1 causes deprecation warnings, see https://github.com/Lendable/clock/runs/4558360650?check_suite_focus=true and https://github.com/Lendable/clock/pull/119.

While 1.6.9 fixes this, as it's a dev tool I don't see the point in not pushing forward on minimum version.