### PR TITLE
Remove liuggio/fastest as not used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
   "require-dev": {
     "ext-json": "*",
     "friendsofphp/php-cs-fixer": "^3.0",
-    "liuggio/fastest": "^1.8",
     "mikey179/vfsstream": "^1.6.10",
     "php-parallel-lint/php-parallel-lint": "^1.3",
     "phpstan/phpstan": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f030fe6f971f5288104c3abd243c5927",
+    "content-hash": "9985a48c21e0e17da60b1823d887c0ac",
     "packages": [],
     "packages-dev": [
         {
@@ -298,75 +298,6 @@
             "time": "2021-08-05T19:00:23+00:00"
         },
         {
-            "name": "doctrine/collections",
-            "version": "1.6.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/collections.git",
-                "reference": "1958a744696c6bb3bb0d28db2611dc11610e78af"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/collections/zipball/1958a744696c6bb3bb0d28db2611dc11610e78af",
-                "reference": "1958a744696c6bb3bb0d28db2611dc11610e78af",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9.0",
-                "phpstan/phpstan": "^0.12",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.1.5",
-                "vimeo/psalm": "^4.2.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Collections\\": "lib/Doctrine/Common/Collections"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "PHP Doctrine Collections library that adds additional functionality on top of PHP arrays.",
-            "homepage": "https://www.doctrine-project.org/projects/collections.html",
-            "keywords": [
-                "array",
-                "collections",
-                "iterators",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/collections/issues",
-                "source": "https://github.com/doctrine/collections/tree/1.6.8"
-            },
-            "time": "2021-08-10T18:51:53+00:00"
-        },
-        {
             "name": "doctrine/instantiator",
             "version": "1.4.0",
             "source": {
@@ -603,69 +534,6 @@
                 }
             ],
             "time": "2021-12-11T16:25:08+00:00"
-        },
-        {
-            "name": "liuggio/fastest",
-            "version": "v1.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liuggio/fastest.git",
-                "reference": "ea33a99058a43ffa9a4c9e2787defa85fe513b0b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liuggio/fastest/zipball/ea33a99058a43ffa9a4c9e2787defa85fe513b0b",
-                "reference": "ea33a99058a43ffa9a4c9e2787defa85fe513b0b",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/collections": "^1.2",
-                "php": "^7.3 || ^8.0",
-                "symfony/console": "^4.4|^5.0",
-                "symfony/process": "^4.4.35|^5.0",
-                "symfony/stopwatch": "^4.4|^5.0"
-            },
-            "require-dev": {
-                "behat/behat": "^3.6",
-                "phpstan/phpstan": "^0.12.99",
-                "phpstan/phpstan-phpunit": "^0.12.22"
-            },
-            "suggest": {
-                "behat/behat": "Install it if you want to run tests with the provided Behat extension"
-            },
-            "bin": [
-                "fastest"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Liuggio\\Fastest\\": [
-                        "src",
-                        "adapters"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "liuggio",
-                    "email": "liuggio@gmail.com"
-                }
-            ],
-            "description": "Simple parallel testing execution... with some goodies for functional tests.",
-            "support": {
-                "issues": "https://github.com/liuggio/fastest/issues",
-                "source": "https://github.com/liuggio/fastest/tree/v1.9.0"
-            },
-            "time": "2021-12-17T07:56:59+00:00"
         },
         {
             "name": "mikey179/vfsstream",


### PR DESCRIPTION
Came from a repository template forever ago, we don't require parallel tests on this library.