### PR TITLE
Add support for offsetting a Date by a number of days

### DIFF
--- a/lib/Date.php
+++ b/lib/Date.php
@@ -103,6 +103,15 @@ final class Date
         return !$this->isBefore($start) && !$this->isAfter($end);
     }
 
+    public function offsetByDays(int $days): self
+    {
+        if ($days === 0) {
+            return $this;
+        }
+
+        return $this->modify(\sprintf('%d days', $days));
+    }
+
     public function toDateTime(): \DateTimeImmutable
     {
         return DateTimeFactory::immutableFromFormat(
@@ -138,8 +147,6 @@ final class Date
 
     private function modify(string $modification): self
     {
-        $modified = $this->toDateTime()->modify($modification);
-
-        return self::fromDateTime($modified);
+        return self::fromDateTime($this->toDateTime()->modify($modification));
     }
 }

--- a/tests/unit/DateTest.php
+++ b/tests/unit/DateTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Lendable\Clock\Unit;
 
-use Lendable\Clock\Date\InvalidDate;
 use Lendable\Clock\Date;
+use Lendable\Clock\Date\InvalidDate;
 use Lendable\Clock\DateTimeFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -385,5 +385,38 @@ final class DateTest extends TestCase
         $diff = $date1->diff($date2);
 
         $this->assertSame($expectedDiff->days, $diff->days);
+    }
+
+    /**
+     * @return iterable<array{int}>
+     */
+    public function provideNumberOfDayOffsets(): iterable
+    {
+        yield [-10];
+        yield [-5];
+        yield [-1];
+        yield [0];
+        yield [1];
+        yield [5];
+        yield [10];
+    }
+
+    /**
+     * @test
+     * @dataProvider provideNumberOfDayOffsets
+     */
+    public function it_can_be_offset_by_days(int $days): void
+    {
+        $date = Date::fromYearMonthDay(2022, 5, 1);
+
+        $offsetDate = $date->offsetByDays($days);
+
+        $expectedDate = Date::fromDateTime($date->toDateTime()->modify(\sprintf('%d days', $days)));
+
+        if ($days !== 0) {
+            $this->assertNotSame($date, $offsetDate);
+        }
+
+        $this->assertTrue($expectedDate->equals($offsetDate));
     }
 }


### PR DESCRIPTION
This currently requires you to convert to a `DateTime` via `toDateTime` and call `modify()`, and manually reconstruct from that `DateTimeImmutable` instance. This PR provides a directly usable API on the `Date` class.