### PR TITLE
Update Renovate to not ignore PHP version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
   ],
   "prHourlyLimit": 0,
   "rangeStrategy": "update-lockfile",
-  "composerIgnorePlatformReqs": ["ext-*", "lib-*", "php"],
+  "composerIgnorePlatformReqs": ["ext-*", "lib-*"],
   "automerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",


### PR DESCRIPTION
We have Composer configured now to cap at 8.0.x as minimum required for dependencies, this fixes Renovate trying to update to packages that require 8.1, namely Symfony 6.1.