### PR TITLE
Check code style only with locked dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
         run: "composer audit"
 
       - name: "Run coding style"
+        if: ${{ matrix.dependencies == 'locked' }}
         run: "composer code-style:check"
 
       - name: "Run PHPStan"


### PR DESCRIPTION
Don't think there is any reason to run the code style for each dependency group.