### PR TITLE
Update to PHPUnit 10 and some general house keeping

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -13,6 +13,7 @@ return (new PhpCsFixer\Config())
         '@PHP73Migration' => true,
         '@PHP74Migration' => true,
         '@PHP80Migration' => true,
+        '@PHP81Migration' => true,
         '@DoctrineAnnotation' => true,
         'align_multiline_comment' => true,
         'array_indentation' => true,

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "phpstan/phpstan-deprecation-rules": "^1.1.1",
     "phpstan/phpstan-phpunit": "^1.3.3",
     "phpstan/phpstan-strict-rules": "^1.4.5",
-    "phpunit/phpunit": "^9.6.3",
+    "phpunit/phpunit": "^10.0.4",
     "rector/rector": "^0.15"
   },
   "provide": {

--- a/composer.json
+++ b/composer.json
@@ -90,8 +90,7 @@
       "@tests:unit"
     ],
     "tests:unit": [
-      "@phpunit:unit",
-      "@infection"
+      "@phpunit:unit"
     ],
     "ci": [
       "@composer audit",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2a9d917b9b45cf460ff49e147063c25",
+    "content-hash": "beda1babca7d905739159e66171864f1",
     "packages": [
         {
             "name": "psr/clock",
@@ -396,76 +396,6 @@
                 "source": "https://github.com/doctrine/deprecations/tree/v1.0.0"
             },
             "time": "2022-05-02T15:47:09+00:00"
-        },
-        {
-            "name": "doctrine/instantiator",
-            "version": "1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -1639,16 +1569,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.24",
+            "version": "10.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed"
+                "reference": "bf4fbc9c13af7da12b3ea807574fb460f255daba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2cf940ebc6355a9d430462811b5aaa308b174bed",
-                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/bf4fbc9c13af7da12b3ea807574fb460f255daba",
+                "reference": "bf4fbc9c13af7da12b3ea807574fb460f255daba",
                 "shasum": ""
             },
             "require": {
@@ -1656,18 +1586,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.14",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^3.0",
+                "sebastian/complexity": "^3.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/lines-of-code": "^2.0",
+                "sebastian/version": "^4.0",
                 "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcov": "*",
@@ -1676,7 +1606,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "10.0-dev"
                 }
             },
             "autoload": {
@@ -1704,7 +1634,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.24"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.0.0"
             },
             "funding": [
                 {
@@ -1712,32 +1642,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-26T08:26:55+00:00"
+            "time": "2023-02-03T07:14:34+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "7d66d4e816d34e90acec9db9d8d94b5cfbfe926f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/7d66d4e816d34e90acec9db9d8d94b5cfbfe926f",
+                "reference": "7d66d4e816d34e90acec9db9d8d94b5cfbfe926f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1764,7 +1694,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.0"
             },
             "funding": [
                 {
@@ -1772,28 +1702,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2023-02-03T06:55:11+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -1801,7 +1731,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1827,7 +1757,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
             },
             "funding": [
                 {
@@ -1835,32 +1765,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2023-02-03T06:56:09+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
+                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1886,7 +1816,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.0"
             },
             "funding": [
                 {
@@ -1894,32 +1824,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2023-02-03T06:56:46+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1945,7 +1875,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
             "funding": [
                 {
@@ -1953,24 +1883,23 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.3",
+            "version": "10.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "e7b1615e3e887d6c719121c6d4a44b0ab9645555"
+                "reference": "6be2d07cce2c7f812db007825a57da3b08972eaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e7b1615e3e887d6c719121c6d4a44b0ab9645555",
-                "reference": "e7b1615e3e887d6c719121c6d4a44b0ab9645555",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6be2d07cce2c7f812db007825a57da3b08972eaf",
+                "reference": "6be2d07cce2c7f812db007825a57da3b08972eaf",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -1980,27 +1909,26 @@
                 "myclabs/deep-copy": "^1.10.1",
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.13",
-                "phpunit/php-file-iterator": "^3.0.5",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
-                "sebastian/version": "^3.0.2"
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.0",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-invoker": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "phpunit/php-timer": "^6.0",
+                "sebastian/cli-parser": "^2.0",
+                "sebastian/code-unit": "^2.0",
+                "sebastian/comparator": "^5.0",
+                "sebastian/diff": "^5.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/exporter": "^5.0",
+                "sebastian/global-state": "^6.0",
+                "sebastian/object-enumerator": "^5.0",
+                "sebastian/recursion-context": "^5.0",
+                "sebastian/type": "^4.0",
+                "sebastian/version": "^4.0"
             },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "*"
             },
             "bin": [
                 "phpunit"
@@ -2008,7 +1936,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "10.0-dev"
                 }
             },
             "autoload": {
@@ -2039,7 +1967,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.3"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.0.4"
             },
             "funding": [
                 {
@@ -2055,7 +1983,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-04T13:37:15+00:00"
+            "time": "2023-02-05T16:23:38+00:00"
         },
         {
             "name": "psr/container",
@@ -2341,28 +2269,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/efdc130dbbbb8ef0b545a994fd811725c5282cae",
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2385,7 +2313,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.0"
             },
             "funding": [
                 {
@@ -2393,32 +2321,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:08:49+00:00"
+            "time": "2023-02-03T06:58:15+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2441,7 +2369,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
             },
             "funding": [
                 {
@@ -2449,32 +2377,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2023-02-03T06:58:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2496,7 +2424,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2504,34 +2432,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/72f01e6586e0caf6af81297897bd112eb7e9627c",
+                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2570,7 +2500,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2578,33 +2508,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2023-02-03T07:07:16+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
+                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
-                "php": ">=7.3"
+                "nikic/php-parser": "^4.10",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2627,7 +2557,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2635,33 +2565,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-02-03T06:59:47+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "70dd1b20bc198da394ad542e988381b44e64e39f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/70dd1b20bc198da394ad542e988381b44e64e39f",
+                "reference": "70dd1b20bc198da394ad542e988381b44e64e39f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
+                "phpunit/phpunit": "^10.0",
                 "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2693,7 +2623,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2701,27 +2631,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-02-03T07:00:31+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "b6f3694c6386c7959915a0037652e0c40f6f69cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b6f3694c6386c7959915a0037652e0c40f6f69cc",
+                "reference": "b6f3694c6386c7959915a0037652e0c40f6f69cc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -2729,7 +2659,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2748,7 +2678,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -2756,7 +2686,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.0"
             },
             "funding": [
                 {
@@ -2764,34 +2694,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2023-02-03T07:03:04+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
+                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2833,7 +2763,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2841,38 +2771,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2023-02-03T07:06:49+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.5",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+                "reference": "aab257c712de87b90194febd52e4d184551c2d44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/aab257c712de87b90194febd52e4d184551c2d44",
+                "reference": "aab257c712de87b90194febd52e4d184551c2d44",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2897,7 +2824,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.0"
             },
             "funding": [
                 {
@@ -2905,33 +2832,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-14T08:28:10+00:00"
+            "time": "2023-02-03T07:07:38+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/17c4d940ecafb3d15d2cf916f4108f664e28b130",
+                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
-                "php": ">=7.3"
+                "nikic/php-parser": "^4.10",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2954,7 +2881,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.0"
             },
             "funding": [
                 {
@@ -2962,34 +2889,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-02-03T07:08:02+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3011,7 +2938,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3019,32 +2946,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3066,7 +2993,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
             },
             "funding": [
                 {
@@ -3074,32 +3001,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3129,7 +3056,7 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3137,87 +3064,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2023-02-03T07:05:40+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3240,7 +3112,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
             },
             "funding": [
                 {
@@ -3248,29 +3120,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "5facf5a20311ac44f79221274cdeb6c569ca11dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/5facf5a20311ac44f79221274cdeb6c569ca11dd",
+                "reference": "5facf5a20311ac44f79221274cdeb6c569ca11dd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3293,7 +3165,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.0"
             },
             "funding": [
                 {
@@ -3301,7 +3173,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2023-02-03T07:11:37+00:00"
         },
         {
             "name": "symfony/console",

--- a/lib/DateTimeFactory.php
+++ b/lib/DateTimeFactory.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Lendable\Clock;
 
+use PHPUnit\Framework\Attributes\CodeCoverageIgnore;
+
 /**
  * Provides the ability to construct {@see \DateTime} and {@see \DateTimeImmutable} instances with an API that does
  * not return false on failure.
  */
 final class DateTimeFactory
 {
-    /**
-     * @codeCoverageIgnore
-     */
+    #[CodeCoverageIgnore]
     private function __construct()
     {
     }

--- a/rector.php
+++ b/rector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Core\ValueObject\PhpVersion;
+use Rector\PHPUnit\Set\PHPUnitLevelSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 
@@ -12,8 +13,11 @@ return static function (RectorConfig $rector): void {
     $rector->paths([__DIR__.'/lib', __DIR__.'/tests']);
     $rector->phpVersion(PhpVersion::PHP_81);
     $rector->phpstanConfig(__DIR__.'/phpstan-rector.neon');
+    $rector->importNames();
+    $rector->importShortClasses(false);
     $rector->sets([
         SetList::CODE_QUALITY,
         LevelSetList::UP_TO_PHP_81,
+        PHPUnitLevelSetList::UP_TO_PHPUNIT_100,
     ]);
 };

--- a/tests/support/TickingTimeAssertions.php
+++ b/tests/support/TickingTimeAssertions.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Lendable\Clock\Support;
 
+use PHPUnit\Framework\Attributes\CodeCoverageIgnore;
 use PHPUnit\Framework\Assert;
 
 final class TickingTimeAssertions
 {
-    /**
-     * @codeCoverageIgnore
-     */
+    #[CodeCoverageIgnore]
     private function __construct()
     {
     }

--- a/tests/unit/DateTest.php
+++ b/tests/unit/DateTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Lendable\Clock\Unit;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Lendable\Clock\Date;
 use Lendable\Clock\Date\InvalidDate;
 use Lendable\Clock\DateTimeFactory;
@@ -15,7 +17,7 @@ final class DateTest extends TestCase
     /**
      * @return iterable<array{int, int, int, string}>
      */
-    public function provideValidIntegerComponentsAndExpectedStringRepresentationsData(): iterable
+    public static function provideValidIntegerComponentsAndExpectedStringRepresentationsData(): iterable
     {
         yield [
             2018,
@@ -37,10 +39,8 @@ final class DateTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider provideValidIntegerComponentsAndExpectedStringRepresentationsData
-     */
+    #[DataProvider('provideValidIntegerComponentsAndExpectedStringRepresentationsData')]
+    #[Test]
     public function it_can_be_constructed_from_integer_components(
         int $year,
         int $month,
@@ -52,9 +52,7 @@ final class DateTest extends TestCase
         $this->assertSame($expectedStringRepresentation, $result->toYearMonthDayString());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_when_constructing_from_integer_components_if_invalid_date(): void
     {
         $this->expectException(InvalidDate::class);
@@ -66,7 +64,7 @@ final class DateTest extends TestCase
     /**
      * @return iterable<array{\DateTimeImmutable, string}>
      */
-    public function provideDateTimesAndExpectedStringRepresentationsData(): iterable
+    public static function provideDateTimesAndExpectedStringRepresentationsData(): iterable
     {
         $dateTimeStrings = [
             '2018-12-10 12:00:00' => '2018-12-10',
@@ -86,10 +84,8 @@ final class DateTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     * @dataProvider provideDateTimesAndExpectedStringRepresentationsData
-     */
+    #[DataProvider('provideDateTimesAndExpectedStringRepresentationsData')]
+    #[Test]
     public function it_can_be_constructed_from_a_date_time_instance(
         \DateTimeImmutable $dateTime,
         string $expectedStringRepresentation
@@ -102,7 +98,7 @@ final class DateTest extends TestCase
     /**
      * @return iterable<array{string, string}>
      */
-    public function provideDateTimeStringsAndExpectedStringRepresentationsData(): iterable
+    public static function provideDateTimeStringsAndExpectedStringRepresentationsData(): iterable
     {
         yield [
             '2018-12-10',
@@ -118,10 +114,8 @@ final class DateTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider provideDateTimeStringsAndExpectedStringRepresentationsData
-     */
+    #[DataProvider('provideDateTimeStringsAndExpectedStringRepresentationsData')]
+    #[Test]
     public function it_can_be_constructed_from_a_formatted_string(
         string $dateTimeString,
         string $expectedStringRepresentation
@@ -134,7 +128,7 @@ final class DateTest extends TestCase
     /**
      * @return iterable<array{string}>
      */
-    public function provideInvalidYearMonthDayStrings(): iterable
+    public static function provideInvalidYearMonthDayStrings(): iterable
     {
         yield ['2008-01-04-'];
         yield ['-2008-01-04'];
@@ -145,10 +139,8 @@ final class DateTest extends TestCase
         yield ['2024'];
     }
 
-    /**
-     * @test
-     * @dataProvider provideInvalidYearMonthDayStrings
-     */
+    #[DataProvider('provideInvalidYearMonthDayStrings')]
+    #[Test]
     public function it_throws_when_constructing_from_a_formatted_string_if_invalid_format(string $value): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -157,9 +149,7 @@ final class DateTest extends TestCase
         Date::fromYearMonthDayString($value);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_when_constructing_from_a_formatted_string_if_invalid_date(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -168,9 +158,7 @@ final class DateTest extends TestCase
         Date::fromYearMonthDayString('2019-13-01');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_exposes_the_year_month_and_day(): void
     {
         $date = Date::fromYearMonthDay(2019, 1, 10);
@@ -180,12 +168,10 @@ final class DateTest extends TestCase
         $this->assertSame(10, $date->day());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_be_converted_to_a_utc_datetime_immutable_instance(): void
     {
-        $date = Date::fromYearMonthDay(2019, 02, 15);
+        $date = Date::fromYearMonthDay(2019, 2, 15);
         $dateTimeImmutable = $date->toDateTime();
 
         $this->assertSame('2019-02-15', $dateTimeImmutable->format('Y-m-d'));
@@ -193,16 +179,14 @@ final class DateTest extends TestCase
         $this->assertSame('UTC', $dateTimeImmutable->getTimezone()->getName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_equals_other_dates_with_the_same_value(): void
     {
-        $date = Date::fromYearMonthDay(2019, 01, 02);
-        $dateSameValue = Date::fromYearMonthDay(2019, 01, 02);
-        $dateDifferentValue1 = Date::fromYearMonthDay(2019, 01, 03);
-        $dateDifferentValue2 = Date::fromYearMonthDay(2019, 02, 02);
-        $dateDifferentValue3 = Date::fromYearMonthDay(2018, 01, 02);
+        $date = Date::fromYearMonthDay(2019, 1, 2);
+        $dateSameValue = Date::fromYearMonthDay(2019, 1, 2);
+        $dateDifferentValue1 = Date::fromYearMonthDay(2019, 1, 3);
+        $dateDifferentValue2 = Date::fromYearMonthDay(2019, 2, 2);
+        $dateDifferentValue3 = Date::fromYearMonthDay(2018, 1, 2);
 
         $this->assertTrue($date->equals($dateSameValue));
         $this->assertTrue($dateSameValue->equals($date));
@@ -214,10 +198,8 @@ final class DateTest extends TestCase
         $this->assertFalse($dateDifferentValue3->equals($date));
     }
 
-    /**
-     * @test
-     * @dataProvider provideDatesForDayAfterIncrementData
-     */
+    #[DataProvider('provideDatesForDayAfterIncrementData')]
+    #[Test]
     public function it_will_correctly_increment_for_following_day(string $currentDate, string $expectedDate): void
     {
         $this->assertSame(
@@ -229,7 +211,7 @@ final class DateTest extends TestCase
     /**
      * @return iterable<array{string, string}>
      */
-    public function provideDatesForDayAfterIncrementData(): iterable
+    public static function provideDatesForDayAfterIncrementData(): iterable
     {
         yield ['2019-01-04', '2019-01-05'];
         yield ['2018-12-31', '2019-01-01'];
@@ -238,10 +220,8 @@ final class DateTest extends TestCase
         yield ['2020-04-30', '2020-05-01'];
     }
 
-    /**
-     * @test
-     * @dataProvider provideDatesForDayBeforeIncrementData
-     */
+    #[DataProvider('provideDatesForDayBeforeIncrementData')]
+    #[Test]
     public function it_will_correctly_increment_for_previous_day(string $currentDate, string $expectedDate): void
     {
         $this->assertSame(
@@ -253,17 +233,15 @@ final class DateTest extends TestCase
     /**
      * @return iterable<array{string, string}>
      */
-    public function provideDatesForDayBeforeIncrementData(): iterable
+    public static function provideDatesForDayBeforeIncrementData(): iterable
     {
-        foreach ($this->provideDatesForDayAfterIncrementData() as $args) {
+        foreach (self::provideDatesForDayAfterIncrementData() as $args) {
             yield \array_reverse($args);
         }
     }
 
-    /**
-     * @test
-     * @dataProvider provideValuesForBeforeComparisonData
-     */
+    #[DataProvider('provideValuesForBeforeComparisonData')]
+    #[Test]
     public function it_will_return_correct_values_for_before_comparison(
         string $before,
         string $after,
@@ -278,7 +256,7 @@ final class DateTest extends TestCase
     /**
      * @return iterable<array{string, string, bool}>
      */
-    public function provideValuesForBeforeComparisonData(): iterable
+    public static function provideValuesForBeforeComparisonData(): iterable
     {
         yield ['2019-01-01', '2019-02-01', true];
         yield ['2020-01-01', '2021-01-01', true];
@@ -289,10 +267,8 @@ final class DateTest extends TestCase
         yield ['2019-01-02', '2019-01-01', false];
     }
 
-    /**
-     * @test
-     * @dataProvider provideValuesForBeforeOrEqualToComparisonData
-     */
+    #[DataProvider('provideValuesForBeforeOrEqualToComparisonData')]
+    #[Test]
     public function it_will_return_correct_values_for_before_or_equal_to_comparison(
         string $before,
         string $after,
@@ -307,7 +283,7 @@ final class DateTest extends TestCase
     /**
      * @return iterable<array{string, string, bool}>
      */
-    public function provideValuesForBeforeOrEqualToComparisonData(): iterable
+    public static function provideValuesForBeforeOrEqualToComparisonData(): iterable
     {
         yield ['2019-01-01', '2019-02-01', true];
         yield ['2020-01-01', '2021-01-01', true];
@@ -318,10 +294,8 @@ final class DateTest extends TestCase
         yield ['2019-01-02', '2019-01-01', false];
     }
 
-    /**
-     * @test
-     * @dataProvider provideValuesForAfterComparisonData
-     */
+    #[DataProvider('provideValuesForAfterComparisonData')]
+    #[Test]
     public function it_will_return_correct_values_for_after_comparison(
         string $before,
         string $after,
@@ -336,7 +310,7 @@ final class DateTest extends TestCase
     /**
      * @return iterable<array{string, string, bool}>
      */
-    public function provideValuesForAfterComparisonData(): iterable
+    public static function provideValuesForAfterComparisonData(): iterable
     {
         yield ['2019-01-01', '2019-02-01', false];
         yield ['2020-01-01', '2021-01-01', false];
@@ -347,25 +321,21 @@ final class DateTest extends TestCase
         yield ['2019-01-02', '2019-01-01', true];
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_will_return_correct_values_for_between_comparison(): void
     {
         $startDate = Date::fromYearMonthDay(2019, 6, 28);
         $endDate = Date::fromYearMonthDay(2019, 7, 28);
 
-        $this->assertFalse(Date::fromYearMonthDay(2019, 06, 27)->isBetween($startDate, $endDate));
-        $this->assertTrue(Date::fromYearMonthDay(2019, 06, 28)->isBetween($startDate, $endDate));
-        $this->assertTrue(Date::fromYearMonthDay(2019, 07, 13)->isBetween($startDate, $endDate));
-        $this->assertTrue(Date::fromYearMonthDay(2019, 07, 28)->isBetween($startDate, $endDate));
-        $this->assertFalse(Date::fromYearMonthDay(2019, 07, 29)->isBetween($startDate, $endDate));
+        $this->assertFalse(Date::fromYearMonthDay(2019, 6, 27)->isBetween($startDate, $endDate));
+        $this->assertTrue(Date::fromYearMonthDay(2019, 6, 28)->isBetween($startDate, $endDate));
+        $this->assertTrue(Date::fromYearMonthDay(2019, 7, 13)->isBetween($startDate, $endDate));
+        $this->assertTrue(Date::fromYearMonthDay(2019, 7, 28)->isBetween($startDate, $endDate));
+        $this->assertFalse(Date::fromYearMonthDay(2019, 7, 29)->isBetween($startDate, $endDate));
     }
 
-    /**
-     * @test
-     * @dataProvider provideDatesAndDayCountsForDiffComparisonData
-     */
+    #[DataProvider('provideDatesAndDayCountsForDiffComparisonData')]
+    #[Test]
     public function it_will_calculate_difference_between_two_days(
         string $start,
         string $end,
@@ -380,16 +350,14 @@ final class DateTest extends TestCase
     /**
      * @return iterable<array{string, string, int}>
      */
-    public function provideDatesAndDayCountsForDiffComparisonData(): iterable
+    public static function provideDatesAndDayCountsForDiffComparisonData(): iterable
     {
         yield ['2020-02-24', '2020-03-03', 8];
         yield ['2019-02-24', '2019-03-03', 7];
         yield ['2018-01-31', '2018-02-28', 28];
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_calculates_diff_correctly(): void
     {
         $dateTime1 = new \DateTimeImmutable('2020-08-15 00:00:00');
@@ -406,7 +374,7 @@ final class DateTest extends TestCase
     /**
      * @return iterable<array{int}>
      */
-    public function provideNumberOfDayOffsets(): iterable
+    public static function provideNumberOfDayOffsets(): iterable
     {
         yield [-10];
         yield [-5];
@@ -417,10 +385,8 @@ final class DateTest extends TestCase
         yield [10];
     }
 
-    /**
-     * @test
-     * @dataProvider provideNumberOfDayOffsets
-     */
+    #[DataProvider('provideNumberOfDayOffsets')]
+    #[Test]
     public function it_can_be_offset_by_days(int $days): void
     {
         $date = Date::fromYearMonthDay(2022, 5, 1);
@@ -436,9 +402,7 @@ final class DateTest extends TestCase
         $this->assertTrue($expectedDate->equals($offsetDate));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_be_constructed_from_a_number_of_years_ago(): void
     {
         $clock = new SystemClock();

--- a/tests/unit/DateTimeFactoryTest.php
+++ b/tests/unit/DateTimeFactoryTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Lendable\Clock\Unit;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Lendable\Clock\DateTimeFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -12,17 +14,15 @@ final class DateTimeFactoryTest extends TestCase
     /**
      * @return iterable<array{string}>
      */
-    public function provideTimezones(): iterable
+    public static function provideTimezones(): iterable
     {
         yield ['Europe/Paris'];
         yield ['Europe/Berlin'];
         yield ['Europe/London'];
     }
 
-    /**
-     * @test
-     * @dataProvider provideTimezones
-     */
+    #[DataProvider('provideTimezones')]
+    #[Test]
     public function it_creates_immutable_instances_with_the_system_default_timezone_if_one_is_not_provided(string $timezone): void
     {
         $this->runWithDefaultTimezone($timezone, function () use ($timezone): void {
@@ -35,9 +35,7 @@ final class DateTimeFactoryTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_creates_immutable_instances_with_the_given_timezone(): void
     {
         $timestamp = '2022-04-03 10:20:30';
@@ -48,9 +46,7 @@ final class DateTimeFactoryTest extends TestCase
         $this->assertTimestampAndTimezoneEquals($timestamp, $format, $timezone, $instance);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_an_exception_if_an_immutable_instance_fails_to_construct(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -59,10 +55,8 @@ final class DateTimeFactoryTest extends TestCase
         DateTimeFactory::immutableFromFormat('ABC123', '1234567');
     }
 
-    /**
-     * @test
-     * @dataProvider provideTimezones
-     */
+    #[DataProvider('provideTimezones')]
+    #[Test]
     public function it_creates_mutable_instances_with_the_system_default_timezone_if_one_is_not_provided(string $timezone): void
     {
         $this->runWithDefaultTimezone($timezone, function () use ($timezone): void {
@@ -75,9 +69,7 @@ final class DateTimeFactoryTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_creates_mutable_instances_with_the_given_timezone(): void
     {
         $timestamp = '2022-04-03 10:20:30';
@@ -88,9 +80,7 @@ final class DateTimeFactoryTest extends TestCase
         $this->assertTimestampAndTimezoneEquals($timestamp, $format, $timezone, $instance);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_an_exception_if_a_mutable_instance_fails_to_construct(): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/unit/FixedClockTest.php
+++ b/tests/unit/FixedClockTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Lendable\Clock\Unit;
 
+use PHPUnit\Framework\Attributes\Test;
 use Lendable\Clock\FixedClock;
 use PHPUnit\Framework\TestCase;
 
 final class FixedClockTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_always_returns_the_given_time(): void
     {
         $timeString = '2018-04-07T16:51:29.083869';
@@ -29,9 +28,7 @@ final class FixedClockTest extends TestCase
         $this->assertSame($timeString, $clock->nowMutable()->format($timeFormat));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_change_the_time_to_a_new_fixed_value(): void
     {
         $timeString = '2021-05-05T14:11:49.128311';
@@ -48,9 +45,7 @@ final class FixedClockTest extends TestCase
         $this->assertSame('2021-05-05T14:41:49.128311', $clock->nowMutable()->format($timeFormat));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_rewind_time(): void
     {
         $timeString = '2021-05-05T14:11:49.128311';
@@ -65,9 +60,7 @@ final class FixedClockTest extends TestCase
         $this->assertSame('2021-05-05T13:41:49.128311', $clock->nowMutable()->format($timeFormat));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_advance_time(): void
     {
         $timeString = '2021-05-05T14:11:49.128311';
@@ -82,9 +75,7 @@ final class FixedClockTest extends TestCase
         $this->assertSame('2021-05-05T14:41:49.128311', $clock->nowMutable()->format($timeFormat));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_return_a_date_object(): void
     {
         $timeString = '2018-04-07T16:51:29.083869';

--- a/tests/unit/PersistedFixedClockTest.php
+++ b/tests/unit/PersistedFixedClockTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Lendable\Clock\Unit;
 
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Lendable\Clock\PersistedFixedClock;
 use Lendable\Clock\Serialization\FixedFileNameGenerator;
 use org\bovigo\vfs\vfsStream;
@@ -11,9 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 final class PersistedFixedClockTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_reuses_the_serialized_value_when_reconstructed_from(): void
     {
         $vfs = vfsStream::setup('serialized_time');
@@ -30,9 +30,7 @@ final class PersistedFixedClockTest extends TestCase
         $this->assertSame($timeString, PersistedFixedClock::fromPersisted($vfs->url(), $fileNameGenerator)->nowMutable()->format($timeFormat));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_always_returns_the_given_time(): void
     {
         $vfs = vfsStream::setup('serialized_time');
@@ -51,9 +49,7 @@ final class PersistedFixedClockTest extends TestCase
         $this->assertSame($timeString, $clock->nowMutable()->format($timeFormat));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_return_a_date_object(): void
     {
         $vfs = vfsStream::setup('serialized_time');
@@ -70,9 +66,7 @@ final class PersistedFixedClockTest extends TestCase
         $this->assertEquals(7, $date->day());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_change_the_time_to_a_new_fixed_value(): void
     {
         $vfs = vfsStream::setup('serialized_time');
@@ -98,9 +92,7 @@ final class PersistedFixedClockTest extends TestCase
         $this->assertSame($expectedTimestamp, $clock->nowMutable()->format($timeFormat));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_rewind_time(): void
     {
         $vfs = vfsStream::setup('serialized_time');
@@ -125,9 +117,7 @@ final class PersistedFixedClockTest extends TestCase
         $this->assertSame($expectedTimestamp, $clock->nowMutable()->format($timeFormat));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_advance_time(): void
     {
         $vfs = vfsStream::setup('serialized_time');
@@ -155,7 +145,7 @@ final class PersistedFixedClockTest extends TestCase
     /**
      * @return iterable<string, array{string, string}>
      */
-    public function provideInvalidData(): iterable
+    public static function provideInvalidData(): iterable
     {
         yield 'int' => ['1', 'Expected data to decode to an array, but got int.'];
         yield 'bool' => ['true', 'Expected data to decode to an array, but got bool.'];
@@ -191,10 +181,8 @@ final class PersistedFixedClockTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider provideInvalidData
-     */
+    #[DataProvider('provideInvalidData')]
+    #[Test]
     public function it_throws_when_loaded_data_is_not_an_array_or_is_invalid(string $serializedData, string $expectedExceptionMessage): void
     {
         $vfs = vfsStream::setup('serialized_time');

--- a/tests/unit/Serialization/FastestTestChannelFileNameGeneratorTest.php
+++ b/tests/unit/Serialization/FastestTestChannelFileNameGeneratorTest.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Lendable\Clock\Unit\Serialization;
 
+use PHPUnit\Framework\Attributes\Test;
 use Lendable\Clock\Serialization\FastestTestChannelFileNameGenerator;
 use Liuggio\Fastest\Process\EnvCommandCreator;
 use PHPUnit\Framework\TestCase;
 
 final class FastestTestChannelFileNameGeneratorTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_bases_the_file_name_off_the_env_var_exposed_by_fastest(): void
     {
         $this->exerciseAndResetEnv(function (): void {
@@ -21,9 +20,7 @@ final class FastestTestChannelFileNameGeneratorTest extends TestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_defaults_to_1_when_the_env_var_is_not_provided(): void
     {
         $this->exerciseAndResetEnv(function (): void {

--- a/tests/unit/Serialization/FixedFileNameGeneratorTest.php
+++ b/tests/unit/Serialization/FixedFileNameGeneratorTest.php
@@ -4,22 +4,19 @@ declare(strict_types=1);
 
 namespace Tests\Lendable\Clock\Unit\Serialization;
 
+use PHPUnit\Framework\Attributes\Test;
 use Lendable\Clock\Serialization\FixedFileNameGenerator;
 use PHPUnit\Framework\TestCase;
 
 final class FixedFileNameGeneratorTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_generates_the_fixed_given_file_name(): void
     {
         $this->assertSame('foo.json', (new FixedFileNameGenerator('foo.json'))->generate());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_defaults_to_a_name(): void
     {
         $this->assertSame('now.json', (new FixedFileNameGenerator())->generate());

--- a/tests/unit/SystemClockTest.php
+++ b/tests/unit/SystemClockTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Lendable\Clock\Unit;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Lendable\Clock\SystemClock;
 use PHPUnit\Framework\TestCase;
 
@@ -12,7 +14,7 @@ final class SystemClockTest extends TestCase
     /**
      * @phpstan-return iterable<array{0: string}>
      */
-    public function exampleTimeZoneNames(): iterable
+    public static function exampleTimeZoneNames(): iterable
     {
         yield ['UTC'];
         yield ['America/New_York'];
@@ -20,10 +22,8 @@ final class SystemClockTest extends TestCase
         yield ['Europe/Paris'];
     }
 
-    /**
-     * @test
-     * @dataProvider exampleTimeZoneNames
-     */
+    #[DataProvider('exampleTimeZoneNames')]
+    #[Test]
     public function it_gives_a_time_in_the_configured_timezone(string $timeZoneName): void
     {
         $clock = new SystemClock(new \DateTimeZone($timeZoneName));
@@ -31,17 +31,13 @@ final class SystemClockTest extends TestCase
         $this->assertSame($timeZoneName, $clock->now()->getTimezone()->getName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_defaults_timezone_to_utc(): void
     {
         $this->assertSame('UTC', (new SystemClock())->now()->getTimezone()->getName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_gives_the_current_system_time(): void
     {
         $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
@@ -58,9 +54,7 @@ final class SystemClockTest extends TestCase
         $this->assertLessThanOrEqual(1, $difference);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_return_a_date_object(): void
     {
         $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));

--- a/tests/unit/TickingMockClockTest.php
+++ b/tests/unit/TickingMockClockTest.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Lendable\Clock\Unit;
 
+use PHPUnit\Framework\Attributes\Test;
 use Lendable\Clock\TickingMockClock;
 use PHPUnit\Framework\TestCase;
 use Tests\Lendable\Clock\Support\TickingTimeAssertions;
 
 final class TickingMockClockTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_returns_time_that_has_ticked(): void
     {
         $timeString = '2018-04-07T16:51:29.083869';
@@ -63,9 +62,7 @@ final class TickingMockClockTest extends TestCase
         TickingTimeAssertions::assertDateTimeLessThanOneSecondAfter($now, $sample3);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
      public function it_changes_the_time(): void
      {
          $timeString = '2021-05-05T14:11:49.128311';
@@ -82,9 +79,7 @@ final class TickingMockClockTest extends TestCase
          TickingTimeAssertions::assertDateTimeLessThanOneSecondAfter($updatedTime, $clock->nowMutable());
      }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_provides_the_date_from_its_current_time(): void
     {
         $timeString = '2018-04-07T16:51:29.083869';
@@ -100,9 +95,7 @@ final class TickingMockClockTest extends TestCase
         $this->assertSame(7, $date->day());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_advances_the_date_once_it_has_been_ticking_for_24_hours(): void
     {
         $timeString = '2018-04-07T16:51:29.083869';
@@ -118,9 +111,7 @@ final class TickingMockClockTest extends TestCase
         $this->assertSame(8, $date->day());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_rewind_time(): void
     {
         $timeString = '2021-05-05T14:11:49.128311';
@@ -135,9 +126,7 @@ final class TickingMockClockTest extends TestCase
         TickingTimeAssertions::assertDateTimeLessThanOneSecondAfter($now->sub(new \DateInterval('PT30M')), $clock->nowMutable());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_advance_time(): void
     {
         $timeString = '2021-05-05T14:11:49.128311';


### PR DESCRIPTION
* Fixes some `0` prefixed integers that were being interpreted as octal in test suite when the intent was for formatting (!!!).
* Adds php-cs-fixer migration to 8.1 ruleset.
* Rector's test suite to PHPUnit 10 attributes.
* Require PHPUnit 10.
* Disables Infection as it's reporting mutants under PHPUnit 10 which _are_ covered by the test suite and appears to be an issue upstream.