### PR TITLE
Re-enable Infection in CI without --only-covering-test-cases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,13 +84,14 @@
       "phpunit --colors --testsuite=unit --do-not-cache-result"
     ],
     "infection": [
-      "./bin/infection --threads=8 --only-covering-test-cases --min-msi=99 --show-mutations"
+      "./bin/infection --threads=8 --min-msi=99 --show-mutations"
     ],
     "tests": [
       "@tests:unit"
     ],
     "tests:unit": [
-      "@phpunit:unit"
+      "@phpunit:unit",
+      "@infection"
     ],
     "ci": [
       "@composer audit",


### PR DESCRIPTION
Resolves #430, see https://github.com/infection/infection/issues/1825 which highlights this option as the culprit but is still unfixed upstream. We however have enough coverage to run without this flag and have a green build regardless.