### PR TITLE
Set Composer's PHP version based on CI matrix version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           ini-values: memory_limit=-1
 
+      - name: "Update Composer platform version"
+        if: ${{ matrix.dependencies != 'locked' && matrix.php-version != '8.1' }}
+        shell: bash
+        run: "composer config platform.php ${{ matrix.php-version }}"
+
       - name: "Install dependencies"
         uses: ramsey/composer-install@v2
         with:


### PR DESCRIPTION
When running lowest and highest matrices on php 8.2 and 8.3 we should align the platform version with the runtime version to ensure a wider range of dependencies are tested against.