### PR TITLE
Remove attempts to constrain PHP version in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,8 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>Lendable/renovate-config"
-  ],
-  "constraints": {
-    "php": "~8.1.0"
-  }
+  ]
 }


### PR DESCRIPTION
Both attempts to constrain the PHP version dependencies must support failed, removing.