### PR TITLE
chore(ci): normalize quoting in CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: "composer config platform.php ${{ matrix.php-version }}"
 
       - name: "Install dependencies"
-        uses: ramsey/composer-install@v3
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
 


### PR DESCRIPTION
~Renovate isn't picking up `ramsey/composer-install`, it's the only unquoted one but who knows!~ It's not due to this.