### PR TITLE
chore(DEVOPS-7314): migrate to gha scale sets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,9 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           ini-values: memory_limit=-1
-
+        env:
+          runner: self-hosted
+          
       - name: "Update Composer platform version"
         if: ${{ matrix.dependencies != 'locked' && matrix.php-version != '8.2' }}
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   ci:
     name: "Execute (PHP ${{ matrix.php-version }} with ${{ matrix.dependencies }} deps)"
-    runs-on: "ubuntu-latest"
+    runs-on: [ 'lendable-medium-dind-x64-linux' ]
 
     strategy:
       fail-fast: false

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   main:
     name: Validate PR title
-    runs-on: ubuntu-24.04
+    runs-on: [ 'lendable-small-arm64-linux' ]
     steps:
       - uses: benhodgson87/conventional-pull-request-action@v1
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   release-please:
-    runs-on: ubuntu-24.04
+    runs-on: [ 'lendable-small-arm64-linux' ]
     name: Release Automation
     steps:
       - uses: actions/create-github-app-token@v1


### PR DESCRIPTION
[DEVOPS-7314]

We are migrating to GHA ScaleSets - the new version of self-hosted GitHub runners. Please verify the changes:
1. It is using only single label for targeting like that - `[ 'lendable-small-arm64-linux' ]` . If possible follow literally for better future migration experience.
2. For each runner type we have both `arm64` and `x64` variants. Please try to run any generic jobs on arm runners. They offer better price to performance ratio.
3. You can run standard and container jobs on those runners. If you have problems - `#devops-help-desk`. Last resort Dind type runners.
4. Use Dind types `[ 'lendable-medium-dind-x64-linux' ]` only when you need to run `docker`. If your container jobs don't run in standard you can try them here.


[DEVOPS-7314]: https://lendable-uk.atlassian.net/browse/DEVOPS-7314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ