### PR TITLE
fix(DEVOPS-7808): pin changed-files action to a known good version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>Lendable/renovate-config"
+  ]
+}


### PR DESCRIPTION
# [DEVOPS-7808]
## Changes

due to incident https://lendable.slack.com/archives/C08HNKQ4F7G

We are moving all GitHub Action references to git sha1 rather than tags

We will use renovote to achive this and therefore need to enable it in all repositories.

We also need to ensure that all renovate config extends from the [lendable base config](https://github.com/Lendable/renovate-config/blob/main/default.json)


[DEVOPS-7808]: https://lendable-uk.atlassian.net/browse/DEVOPS-7808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ