### PR TITLE
feat: add `Date::earliestOf` and `Date::latestOf` helper functions

### DIFF
--- a/lib/Date.php
+++ b/lib/Date.php
@@ -270,18 +270,14 @@ final readonly class Date
     /**
      * @return self The earliest date from the provided dates.
      */
-    public static function earliestOf(self ...$datesToCompare): self
+    public static function earliestOf(self $date, self ...$otherDatesToCompare): self
     {
-        $earliestDate = null;
+        $earliestDate = $date;
 
-        foreach ($datesToCompare as $date) {
-            if (!$earliestDate instanceof self || $date->isBefore($earliestDate)) {
-                $earliestDate = $date;
+        foreach ($otherDatesToCompare as $otherDate) {
+            if ($otherDate->isBefore($earliestDate)) {
+                $earliestDate = $otherDate;
             }
-        }
-
-        if (!$earliestDate instanceof self) {
-            throw new \InvalidArgumentException('At least one date must be provided.');
         }
 
         return $earliestDate;
@@ -290,18 +286,14 @@ final readonly class Date
     /**
      * @return self The latest date from the provided dates.
      */
-    public static function latestOf(self ...$datesToCompare): self
+    public static function latestOf(self $date, self ...$otherDatesToCompare): self
     {
-        $latestDate = null;
+        $latestDate = $date;
 
-        foreach ($datesToCompare as $date) {
-            if (!$latestDate instanceof self || $date->isAfter($latestDate)) {
-                $latestDate = $date;
+        foreach ($otherDatesToCompare as $otherDate) {
+            if ($otherDate->isAfter($latestDate)) {
+                $latestDate = $otherDate;
             }
-        }
-
-        if (!$latestDate instanceof self) {
-            throw new \InvalidArgumentException('At least one date must be provided.');
         }
 
         return $latestDate;

--- a/lib/Date.php
+++ b/lib/Date.php
@@ -268,34 +268,42 @@ final readonly class Date
     }
 
     /**
-     * @return self The latest date from the provided dates.
+     * @return self The earliest date from the provided dates.
      */
-    public static function max(self $date, self ...$otherDates): self
+    public static function earliestOf(self ...$datesToCompare): self
     {
-        $maxDate = $date;
+        $earliestDate = null;
 
-        foreach ($otherDates as $otherDate) {
-            if ($otherDate->isAfter($maxDate)) {
-                $maxDate = $otherDate;
+        foreach ($datesToCompare as $date) {
+            if (!$earliestDate instanceof self || $date->isBefore($earliestDate)) {
+                $earliestDate = $date;
             }
         }
 
-        return $maxDate;
+        if (!$earliestDate instanceof self) {
+            throw new \InvalidArgumentException('At least one date must be provided.');
+        }
+
+        return $earliestDate;
     }
 
     /**
-     * @return self The earliest date from the provided dates.
+     * @return self The latest date from the provided dates.
      */
-    public static function min(self $date, self ...$otherDates): self
+    public static function latestOf(self ...$datesToCompare): self
     {
-        $minDate = $date;
+        $latestDate = null;
 
-        foreach ($otherDates as $otherDate) {
-            if ($otherDate->isBefore($minDate)) {
-                $minDate = $otherDate;
+        foreach ($datesToCompare as $date) {
+            if (!$latestDate instanceof self || $date->isAfter($latestDate)) {
+                $latestDate = $date;
             }
         }
 
-        return $minDate;
+        if (!$latestDate instanceof self) {
+            throw new \InvalidArgumentException('At least one date must be provided.');
+        }
+
+        return $latestDate;
     }
 }

--- a/lib/Date.php
+++ b/lib/Date.php
@@ -266,4 +266,36 @@ final readonly class Date
             \sprintf('%d-%02d-%02d', $year, $month, 1),
         )->format('t');
     }
+
+    /**
+     * @return self The latest date from the provided dates.
+     */
+    public static function max(self $date, self ...$otherDates): self
+    {
+        $maxDate = $date;
+
+        foreach ($otherDates as $otherDate) {
+            if ($otherDate->isAfter($maxDate)) {
+                $maxDate = $otherDate;
+            }
+        }
+
+        return $maxDate;
+    }
+
+    /**
+     * @return self The earliest date from the provided dates.
+     */
+    public static function min(self $date, self ...$otherDates): self
+    {
+        $minDate = $date;
+
+        foreach ($otherDates as $otherDate) {
+            if ($otherDate->isBefore($minDate)) {
+                $minDate = $otherDate;
+            }
+        }
+
+        return $minDate;
+    }
 }

--- a/tests/unit/DateTest.php
+++ b/tests/unit/DateTest.php
@@ -711,14 +711,6 @@ final class DateTest extends TestCase
         yield [['2018-01-02', '2018-01-01', '2018-01-03', '2018-01-04', '2018-01-05'], '2018-01-01'];
     }
 
-    #[Test]
-    public function it_throws_when_earliest_of_is_called_with_no_arguments(): void
-    {
-        $this->expectExceptionObject(new \InvalidArgumentException('At least one date must be provided.'));
-
-        Date::earliestOf();
-    }
-
     /**
      * @param non-empty-list<string> $dates
      */
@@ -742,13 +734,5 @@ final class DateTest extends TestCase
         yield [['2018-01-01'], '2018-01-01'];
         yield [['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04'], '2018-01-04'];
         yield [['2018-01-01', '2018-01-05', '2018-01-03', '2018-01-04', '2018-01-02'], '2018-01-05'];
-    }
-
-    #[Test]
-    public function it_throws_when_latest_of_is_called_with_no_arguments(): void
-    {
-        $this->expectExceptionObject(new \InvalidArgumentException('At least one date must be provided.'));
-
-        Date::latestOf();
     }
 }

--- a/tests/unit/DateTest.php
+++ b/tests/unit/DateTest.php
@@ -690,49 +690,65 @@ final class DateTest extends TestCase
      * @param non-empty-list<string> $dates
      */
     #[Test]
-    #[DataProvider('provideMaxDates')]
-    public function it_returns_max_date(array $dates, string $expectedDate): void
+    #[DataProvider('provideEarliestOfDates')]
+    public function it_returns_earliest_of_dates(array $dates, string $expectedDate): void
     {
         $arguments = \array_map(static fn (string $date): Date => Date::fromYearMonthDayString($date), $dates);
 
         $this->assertSame(
             $expectedDate,
-            Date::max(...$arguments)->toYearMonthDayString()
+            Date::earliestOf(...$arguments)->toYearMonthDayString()
         );
     }
 
     /**
      * @return iterable<array{non-empty-list<string>, string}>
      */
-    public static function provideMaxDates(): iterable
+    public static function provideEarliestOfDates(): iterable
     {
         yield [['2018-01-01'], '2018-01-01'];
-        yield [['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04'], '2018-01-04'];
-        yield [['2018-01-01', '2018-01-05', '2018-01-03', '2018-01-04', '2018-01-02'], '2018-01-05'];
+        yield [['2018-01-05', '2018-01-02', '2018-01-03', '2018-01-04'], '2018-01-02'];
+        yield [['2018-01-02', '2018-01-01', '2018-01-03', '2018-01-04', '2018-01-05'], '2018-01-01'];
+    }
+
+    #[Test]
+    public function it_throws_when_earliest_of_is_called_with_no_arguments(): void
+    {
+        $this->expectExceptionObject(new \InvalidArgumentException('At least one date must be provided.'));
+
+        Date::earliestOf();
     }
 
     /**
      * @param non-empty-list<string> $dates
      */
     #[Test]
-    #[DataProvider('provideMinDates')]
-    public function it_returns_min_date(array $dates, string $expectedDate): void
+    #[DataProvider('provideLatestOfDates')]
+    public function it_returns_latest_of_dates(array $dates, string $expectedDate): void
     {
         $arguments = \array_map(static fn (string $date): Date => Date::fromYearMonthDayString($date), $dates);
 
         $this->assertSame(
             $expectedDate,
-            Date::min(...$arguments)->toYearMonthDayString()
+            Date::latestOf(...$arguments)->toYearMonthDayString()
         );
     }
 
     /**
      * @return iterable<array{non-empty-list<string>, string}>
      */
-    public static function provideMinDates(): iterable
+    public static function provideLatestOfDates(): iterable
     {
         yield [['2018-01-01'], '2018-01-01'];
-        yield [['2018-01-05', '2018-01-02', '2018-01-03', '2018-01-04'], '2018-01-02'];
-        yield [['2018-01-02', '2018-01-01', '2018-01-03', '2018-01-04', '2018-01-05'], '2018-01-01'];
+        yield [['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04'], '2018-01-04'];
+        yield [['2018-01-01', '2018-01-05', '2018-01-03', '2018-01-04', '2018-01-02'], '2018-01-05'];
+    }
+
+    #[Test]
+    public function it_throws_when_latest_of_is_called_with_no_arguments(): void
+    {
+        $this->expectExceptionObject(new \InvalidArgumentException('At least one date must be provided.'));
+
+        Date::latestOf();
     }
 }

--- a/tests/unit/DateTest.php
+++ b/tests/unit/DateTest.php
@@ -685,4 +685,54 @@ final class DateTest extends TestCase
         yield [Date::fromYearMonthDay(2018, 10, 10), 31];
         yield [Date::fromYearMonthDay(2020, 2, 1), 29];
     }
+
+    /**
+     * @param non-empty-list<string> $dates
+     */
+    #[Test]
+    #[DataProvider('provideMaxDates')]
+    public function it_returns_max_date(array $dates, string $expectedDate): void
+    {
+        $arguments = \array_map(static fn (string $date): Date => Date::fromYearMonthDayString($date), $dates);
+
+        $this->assertSame(
+            $expectedDate,
+            Date::max(...$arguments)->toYearMonthDayString()
+        );
+    }
+
+    /**
+     * @return iterable<array{non-empty-list<string>, string}>
+     */
+    public static function provideMaxDates(): iterable
+    {
+        yield [['2018-01-01'], '2018-01-01'];
+        yield [['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04'], '2018-01-04'];
+        yield [['2018-01-01', '2018-01-05', '2018-01-03', '2018-01-04', '2018-01-02'], '2018-01-05'];
+    }
+
+    /**
+     * @param non-empty-list<string> $dates
+     */
+    #[Test]
+    #[DataProvider('provideMinDates')]
+    public function it_returns_min_date(array $dates, string $expectedDate): void
+    {
+        $arguments = \array_map(static fn (string $date): Date => Date::fromYearMonthDayString($date), $dates);
+
+        $this->assertSame(
+            $expectedDate,
+            Date::min(...$arguments)->toYearMonthDayString()
+        );
+    }
+
+    /**
+     * @return iterable<array{non-empty-list<string>, string}>
+     */
+    public static function provideMinDates(): iterable
+    {
+        yield [['2018-01-01'], '2018-01-01'];
+        yield [['2018-01-05', '2018-01-02', '2018-01-03', '2018-01-04'], '2018-01-02'];
+        yield [['2018-01-02', '2018-01-01', '2018-01-03', '2018-01-04', '2018-01-05'], '2018-01-01'];
+    }
 }


### PR DESCRIPTION
I often find it necessary to compare two or more `Date` instances in order to establish which one of them is the earliest or the latest.

My proposal here is to add two static methods `Date::max` and `Date::min` that mimic PHP's native `max` and `min` function. 

There's also an alternative naming to consider `latest` and `earliest`, but since we already use native `max` and `min` with `DateTime` I picked these ones.

I also considered adding these as non-static methods that would be used like
```php
$dateA = Date::fromYearMonthDayString('2018-01-01');
$dateB = Date::fromYearMonthDayString('2018-01-02');
$dateC = Date::fromYearMonthDayString('2018-01-03');

$max = $dateA->max($dateB, $dateC);
```
but I think it feels a little wrong and calling it this way
```php
$max = Date::max($dateA, $dateB, $dateC);
```
seems better.



## Update
Methods were renamed to `Date::earliestOf` and `Date::latestOf`.