### PR TITLE
test: kill escaped mutants to achieve MSI=100%

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
       "phpunit --colors --testsuite=unit"
     ],
     "infection": [
-      "./bin/infection --threads=8 --min-msi=98 --show-mutations"
+      "./bin/infection --threads=8 --min-msi=100 --show-mutations"
     ],
     "tests": [
       "@tests:unit"

--- a/tests/unit/DateTest.php
+++ b/tests/unit/DateTest.php
@@ -416,7 +416,9 @@ final class DateTest extends TestCase
 
         $expectedDate = Date::fromDateTime($date->startOfDay()->modify(\sprintf('%d days', $days)));
 
-        if ($days !== 0) {
+        if ($days === 0) {
+            $this->assertSame($date, $offsetDate);
+        } else {
             $this->assertNotSame($date, $offsetDate);
         }
 
@@ -447,7 +449,9 @@ final class DateTest extends TestCase
 
         $expectedDate = Date::fromDateTime($date->startOfDay()->modify(\sprintf('%d months', $days)));
 
-        if ($days !== 0) {
+        if ($days === 0) {
+            $this->assertSame($date, $offsetDate);
+        } else {
             $this->assertNotSame($date, $offsetDate);
         }
 
@@ -478,7 +482,9 @@ final class DateTest extends TestCase
 
         $expectedDate = Date::fromDateTime($date->startOfDay()->modify(\sprintf('%d years', $days)));
 
-        if ($days !== 0) {
+        if ($days === 0) {
+            $this->assertSame($date, $offsetDate);
+        } else {
             $this->assertNotSame($date, $offsetDate);
         }
 


### PR DESCRIPTION
I would like to make a number of improvements for Infection in this repo, like

- achieve MSI=100%
- get rid of time outs; set [maximum allowed time outs](https://infection.github.io/guide/command-line-options.html#max-timeouts) (more on this in separate PRs). Read here about why it matters: https://infection.github.io/2026/01/14/whats-new-in-0.32.3/#The-Problem
- run MT with PHPStan (we recently implemnted an integration to kill Mutants with Static Analysis tools): https://infection.github.io/guide/static-analysis-integration.html
- etc.

This PR kills outstanding escaped mutants and sets MSI to 100%, so now all the mutants must either be killed in the new code or ignored.